### PR TITLE
Fix project name links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [README checklist](https://github.com/ddbeck/readme_checklist)
+# [README checklist](https://github.com/ddbeck/readme-checklist)
 
 by [Daniel D. Beck](https://twitter.com/ddbeck)
 
@@ -19,7 +19,7 @@ checklist for your own use. See
 
 View the latest version of the checklist at:
 
-https://github.com/ddbeck/readme_checklist/checklist.md
+https://github.com/ddbeck/readme-checklist/checklist.md
 
 This checklist a *READ-DO* checklist. If you're starting a new README file,
 follow the checklist like a recipe, reading each step and completing it, in


### PR DESCRIPTION
Some links contained an underscore in the project name instead of a dash.